### PR TITLE
Fix - Improve shop readibility

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -218,6 +218,7 @@ export default class BattleScene extends SceneBase {
   public arenaFlyout: ArenaFlyout;
 
   private fieldOverlay: Phaser.GameObjects.Rectangle;
+  private shopOverlay: Phaser.GameObjects.Rectangle;
   public modifiers: PersistentModifier[];
   private enemyModifiers: PersistentModifier[];
   public uiContainer: Phaser.GameObjects.Container;
@@ -384,6 +385,12 @@ export default class BattleScene extends SceneBase {
     this.fieldOverlay.setOrigin(0, 0);
     this.fieldOverlay.setAlpha(0);
     this.fieldUI.add(this.fieldOverlay);
+
+    this.shopOverlay = this.add.rectangle(0, overlayHeight * -1 - 48, overlayWidth, overlayHeight, 0x070707);
+    this.shopOverlay.setName("rect-shop-overlay");
+    this.shopOverlay.setOrigin(0, 0);
+    this.shopOverlay.setAlpha(0);
+    this.fieldUI.add(this.shopOverlay);
 
     this.modifiers = [];
     this.enemyModifiers = [];
@@ -1388,6 +1395,30 @@ export default class BattleScene extends SceneBase {
     return new Promise(resolve => {
       this.tweens.add({
         targets: this.fieldOverlay,
+        alpha: 0,
+        duration: duration,
+        ease: "Cubic.easeIn",
+        onComplete: () => resolve()
+      });
+    });
+  }
+
+  showShopOverlay(duration: integer): Promise<void> {
+    return new Promise(resolve => {
+      this.tweens.add({
+        targets: this.shopOverlay,
+        alpha: 0.95,
+        ease: "Sine.easeOut",
+        duration: duration,
+        onComplete: () => resolve()
+      });
+    });
+  }
+
+  hideShopOverlay(duration: integer): Promise<void> {
+    return new Promise(resolve => {
+      this.tweens.add({
+        targets: this.shopOverlay,
         alpha: 0,
         duration: duration,
         ease: "Cubic.easeIn",

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -180,7 +180,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
 
     const maxUpgradeCount = typeOptions.map(to => to.upgradeCount).reduce((max, current) => Math.max(current, max), 0);
 
-    this.scene.showFieldOverlay(750);
+    this.scene.showShopOverlay(750);
     this.scene.updateAndShowText(750);
     this.scene.updateMoneyText();
 
@@ -472,7 +472,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.getUi().clearText();
     this.eraseCursor();
 
-    this.scene.hideFieldOverlay(250);
+    this.scene.hideShopOverlay(250);
     this.scene.hideLuckText(250);
 
     const options = this.options.concat(this.shopOptionsRows.flat());

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -570,18 +570,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
     this.itemText = addTextObject(this.scene, 0, 35, this.modifierTypeOption.type.name, TextStyle.PARTY, { align: "center" });
     this.itemText.setOrigin(0.5, 0);
     this.itemText.setAlpha(0);
-    // Call the original function to get the integer color value
-    const colorInt = getModifierTierTextTint(this.modifierTypeOption.type.tier);
-    // Convert the integer color value to a hex string
-    // Use toString(16) to convert to hex, then pad with leading zeros if necessary
-    const textColor  = "#" + colorInt?.toString(16).padStart(6, "0");
-    // Check if the colorInt is null, if it is, use the tint color, otherwise use the hex color to be able to set the shadow color differently to the text color
-    if (!colorInt) {
-      this.itemText.setTint(getModifierTierTextTint(this.modifierTypeOption.type.tier));
-    } else {
-      this.itemText.setColor(textColor);
-    }
-    this.itemText.setShadow(0, 0, "#000000", 16, true, true);
+    this.itemText.setTint(getModifierTierTextTint(this.modifierTypeOption.type.tier));
     this.add(this.itemText);
 
     if (this.modifierTypeOption.cost) {
@@ -589,7 +578,6 @@ class ModifierOption extends Phaser.GameObjects.Container {
 
       this.itemCostText.setOrigin(0.5, 0);
       this.itemCostText.setAlpha(0);
-      this.itemCostText.setShadow(0, 0, "#000000", 16, true, true);
       this.add(this.itemCostText);
 
       this.updateCostText();

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -198,10 +198,10 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
   case TextStyle.PARTY_RED:
     return !shadow ? "#f89890" : "#984038";
   case TextStyle.SUMMARY:
-    return !shadow ? "#ffffff" : "#636363";
+    return !shadow ? "#f8f8f8" : "#636363";
   case TextStyle.SUMMARY_ALT:
     if (uiTheme) {
-      return !shadow ? "#ffffff" : "#636363";
+      return !shadow ? "#f8f8f8" : "#636363";
     }
     return !shadow ? "#484848" : "#d0d0c8";
   case TextStyle.SUMMARY_RED:
@@ -233,17 +233,17 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
 export function getModifierTierTextTint(tier: ModifierTier): integer {
   switch (tier) {
   case ModifierTier.COMMON:
-    return 0xffffff;
+    return 0xf8f8f8;
   case ModifierTier.GREAT:
-    return 0x3890f8;
+    return 0x4998f8;
   case ModifierTier.ULTRA:
     return 0xf8d038;
   case ModifierTier.ROGUE:
-    return 0xd52929;
+    return 0xdb4343;
   case ModifierTier.MASTER:
-    return 0xe020c0;
+    return 0xe331c5;
   case ModifierTier.LUXURY:
-    return 0xe64a18;
+    return 0xe74c18;
   }
 }
 

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -235,15 +235,15 @@ export function getModifierTierTextTint(tier: ModifierTier): integer {
   case ModifierTier.COMMON:
     return 0xffffff;
   case ModifierTier.GREAT:
-    return 0x5da3f9;
+    return 0x3890f8;
   case ModifierTier.ULTRA:
     return 0xf8d038;
   case ModifierTier.ROGUE:
-    return 0xe38787;
+    return 0xd52929;
   case ModifierTier.MASTER:
-    return 0xec74d8;
+    return 0xe020c0;
   case ModifierTier.LUXURY:
-    return 0xee825d;
+    return 0xe64a18;
   }
 }
 


### PR DESCRIPTION
## Changes
 - Reverts previous modifications
 - Change colors for better contrast score (makes reading easier)
 - Corrects colors that were totally white when they should have been `f8f8f8` like the others
 - Created a new overlay especially for the shop
   > This one is an almost black color with a higher opacity. This makes the shop elements easier to read, as they blend much less into the UI underneath

## Files changed
- `src/battle-scene.ts`
  > Add an overlay by duplicating it from a pre-existing one
  > Added methods for displaying and hiding it, duplicating those already present
- `src/ui/modifier-select-ui-handler.ts`
  > Replacing the old `showFieldOverlay` and `hideFieldOverlay` methods with the newly created ones
- `src/ui/text.ts`
  > Corrects all-white `#ffffff` colors to `#f8f8f8` as they should have been from the start
  > Corrects the color of tiers so that the contrast score is sufficient to improve legibility