### PR TITLE
[Enhancement] Filter modifiers on shop UI

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -743,6 +743,10 @@ export default class BattleScene extends SceneBase {
       : ret;
   }
 
+  /**
+   * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
+   * @returns {@linkcode ModifierBar}
+   */
   getModifierBar(): ModifierBar {
     return this.modifierBar;
   }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -745,7 +745,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
-   * @returns {@linkcode ModifierBar}
+   * @returns {ModifierBar}
    */
   getModifierBar(): ModifierBar {
     return this.modifierBar;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -743,6 +743,10 @@ export default class BattleScene extends SceneBase {
       : ret;
   }
 
+  getModifierBar(): ModifierBar {
+    return this.modifierBar;
+  }
+
   // store info toggles to be accessible by the ui
   addInfoToggle(infoToggle: InfoToggle): void {
     this.infoToggles.push(infoToggle);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -61,14 +61,14 @@ export class ModifierBar extends Phaser.GameObjects.Container {
     this.setScale(0.5);
   }
 
-  updateModifiers(modifiers: PersistentModifier[], showNonHeldItemModifierOnly: boolean = false) {
+  updateModifiers(modifiers: PersistentModifier[], hideHeldItems: boolean = false) {
     this.removeAll(true);
 
     const visibleIconModifiers = modifiers.filter(m => m.isIconVisible(this.scene as BattleScene));
     const nonPokemonSpecificModifiers = visibleIconModifiers.filter(m => !(m as PokemonHeldItemModifier).pokemonId).sort(modifierSortFunc);
     const pokemonSpecificModifiers = visibleIconModifiers.filter(m => (m as PokemonHeldItemModifier).pokemonId).sort(modifierSortFunc);
 
-    const sortedVisibleIconModifiers = showNonHeldItemModifierOnly ? nonPokemonSpecificModifiers : nonPokemonSpecificModifiers.concat(pokemonSpecificModifiers);
+    const sortedVisibleIconModifiers = hideHeldItems ? nonPokemonSpecificModifiers : nonPokemonSpecificModifiers.concat(pokemonSpecificModifiers);
 
     const thisArg = this;
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -61,13 +61,14 @@ export class ModifierBar extends Phaser.GameObjects.Container {
     this.setScale(0.5);
   }
 
-  updateModifiers(modifiers: PersistentModifier[]) {
+  updateModifiers(modifiers: PersistentModifier[], showNonHeldItemModifierOnly: boolean = false) {
     this.removeAll(true);
 
     const visibleIconModifiers = modifiers.filter(m => m.isIconVisible(this.scene as BattleScene));
     const nonPokemonSpecificModifiers = visibleIconModifiers.filter(m => !(m as PokemonHeldItemModifier).pokemonId).sort(modifierSortFunc);
     const pokemonSpecificModifiers = visibleIconModifiers.filter(m => (m as PokemonHeldItemModifier).pokemonId).sort(modifierSortFunc);
-    const sortedVisibleIconModifiers = nonPokemonSpecificModifiers.concat(pokemonSpecificModifiers);
+
+    const sortedVisibleIconModifiers = showNonHeldItemModifierOnly ? nonPokemonSpecificModifiers : nonPokemonSpecificModifiers.concat(pokemonSpecificModifiers);
 
     const thisArg = this;
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -61,6 +61,11 @@ export class ModifierBar extends Phaser.GameObjects.Container {
     this.setScale(0.5);
   }
 
+  /**
+   * Method to update content displayed in {@linkcode ModifierBar}
+   * @param {PersistentModifier[]} modifiers - The list of modifiers to be displayed in the {@linkcode ModifierBar}
+   * @param {boolean} hideHeldItems - If set to "true", only modifiers not assigned to a Pokémon are displayed
+   */
   updateModifiers(modifiers: PersistentModifier[], hideHeldItems: boolean = false) {
     this.removeAll(true);
 

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -180,6 +180,9 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
 
     const maxUpgradeCount = typeOptions.map(to => to.upgradeCount).reduce((max, current) => Math.max(current, max), 0);
 
+    /* Force updateModifiers without pokemonSpecificModifiers */
+    this.scene.getModifierBar().updateModifiers(this.scene.modifiers, true);
+
     this.scene.showShopOverlay(750);
     this.scene.updateAndShowText(750);
     this.scene.updateMoneyText();
@@ -472,8 +475,11 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.getUi().clearText();
     this.eraseCursor();
 
-    this.scene.hideShopOverlay(250);
+    this.scene.hideShopOverlay(750);
     this.scene.hideLuckText(250);
+
+    /* Normally already called just after the shop, but not sure if it happens in 100% of cases */
+    this.scene.getModifierBar().updateModifiers(this.scene.modifiers);
 
     const options = this.options.concat(this.shopOptionsRows.flat());
     this.options.splice(0, this.options.length);


### PR DESCRIPTION
Modifications requested by @brain-frog

## Changes
 - Add a filter on modifiers displayed in the shop to hide those held by the player's Pokémon
 - Add documentation on methods created and modified for this purpose
 - Longer fade-out time for new shop overlay (from 250ms to 750ms, the same as the fade-in time)

## Files changed
- `src/battle-scene.ts`
  > Add a `getModifierBar()` method to retrieve battle-scene's ModifierBar (which is private) from other interfaces
- `src/ui/modifier-select-ui-handler.ts`
  > Use of the modified `updateModifiers()` method to hide modifiers held by the player's Pokémon during the Shop phase
  > New overlay fade-out time modified (from 250ms to 750ms)
- `src/modifier/modifier.ts`
  > Added a `hideHeldItems` boolean parameter to hide modifiers held by the player's Pokémon when the ModifierBar is updated